### PR TITLE
feat: get pending requests for driver's page has been implemented

### DIFF
--- a/carpool-app/app/controllers/request.controller.js
+++ b/carpool-app/app/controllers/request.controller.js
@@ -320,4 +320,20 @@ exports.acceptRequest = async (req, res) => {
   } catch (err) {
     res.status(500).send({ message: err.message });
   }
+
+  // GET count of pending requests for a publication
+  exports.getPendingRequestsCountForPublication = async (req, res) => {
+    try {
+    const publicationId = req.params.publicationId;
+
+    const pendingRequestsCount = await Request.count({
+      where: { publicationId, status: 'pending' }
+    });
+
+    res.status(200).send({ count: pendingRequestsCount });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
 };

--- a/carpool-app/app/routes/request.routes.js
+++ b/carpool-app/app/routes/request.routes.js
@@ -34,6 +34,9 @@ module.exports = function(app) {
   // Rechazar una solicitud (solo para el driver)
   app.put("/api/requests/reject/:requestId", [authJwt.verifyToken, authJwt.isDriver], requests.rejectRequest);
 
+  // Obtener el número de solicitudes pendientes para una publicación específica
+  app.get("/api/requests/pending/count/:publicationId", [authJwt.verifyToken], requests.getPendingRequestsCountForPublication);
+
   // // Actualizar una solicitud (solo para el passenger)
   // app.put("/api/requests/:requestId", [authJwt.verifyToken], requests.updateRequestByPassenger);
 };


### PR DESCRIPTION
# Purpose

An endpoint to get pending request for specific publication was needed.

## Approach

The previous endpoints were checked and a filter by status added.

## Where should the reviewer start?



`app/controllers/request.controller.js`

`app/routes/request.router.js`

## This PR addresses a:

- [ ] Bug
- [X] Feature
- [ ] Technical Debt
- [ ] Chore
- [ ] Vulnerability
